### PR TITLE
Add model sharing and masking

### DIFF
--- a/config/taxi/classic-2-fickle.yaml
+++ b/config/taxi/classic-2-fickle.yaml
@@ -4,10 +4,16 @@ domain: !!config.taxi.TaxiConfig
   fickle: 0.04
 
 agents:
-  - palmExpert
-
-episodes: 100
-max_steps: 2000
+#    - rmaxqExpert
+  #  - rmaxqHierGen
+    - palmExpert
+    - palmExpertWithNavGiven
+    - palmHierGen
+    - kappaExpert
+    - kappaHierGen
+#    - qLearning
+episodes: 250
+max_steps: 4000
 trials: 1
 gamma: 0.99
 

--- a/config/taxi/classic.yaml
+++ b/config/taxi/classic.yaml
@@ -14,8 +14,8 @@ agents:
   - qLearning
 
 seed: 2320942930
-episodes: 50
-max_steps: 100000
+episodes: 200
+max_steps: 1000
 trials: 1
 gamma: 0.99
 
@@ -26,7 +26,7 @@ planning:
 rmax:
   vmax: 1.0
   threshold: 3
-  max_delta: 0.0000001
+  max_delta: 0.0001
   max_delta_rmaxq: 0.0001
   max_iterations_in_model: 1000
   use_multitime_model: true
@@ -48,7 +48,6 @@ output:
     trial_mode: MOST_RECENT_AND_AVERAGE
 
     metrics:
-                                     
       - STEPS_PER_EPISODE
       - CUMULATIVE_REWARD_PER_STEP
       - CUMULATIVE_REWARD_PER_EPISODE

--- a/config/taxi/classic.yaml
+++ b/config/taxi/classic.yaml
@@ -5,7 +5,7 @@ domain: !!config.taxi.TaxiConfig
 
 agents:
   - rmaxqExpert
-  - rmaxqHierGen
+#  - rmaxqHierGen
   - palmExpert
   - palmExpertWithNavGiven
   - palmHierGen

--- a/src/hierarchy/framework/GroundedTask.java
+++ b/src/hierarchy/framework/GroundedTask.java
@@ -147,6 +147,10 @@ public class GroundedTask {
         return t.reward(s, a, sPrime);
     }
 
+    public boolean isMasked(){
+        return t.isMasked();
+    }
+
     @Override
     public String toString(){
         return formattedName;

--- a/src/hierarchy/framework/Task.java
+++ b/src/hierarchy/framework/Task.java
@@ -5,6 +5,7 @@ import burlap.mdp.core.action.Action;
 import burlap.mdp.core.action.ActionType;
 import burlap.mdp.core.state.State;
 import burlap.mdp.singleagent.oo.OOSADomain;
+import taxi.hierarchies.interfaces.MaskedParameterizedStateMapping;
 import taxi.hierarchies.interfaces.ParameterizedStateMapping;
 
 import java.util.ArrayList;
@@ -32,6 +33,8 @@ public abstract class Task {
      */
     private StateMapping mapper;
 
+    private boolean masked;
+    private String[] maskedParameters;
     /**
      * Setup of variables
      * @param children the task's subtasks
@@ -44,6 +47,12 @@ public abstract class Task {
         this.actionType = aType;
         this.domain = abstractDomain;
         this.mapper = map;
+        this.masked = (map instanceof MaskedParameterizedStateMapping);
+        if(this.masked){
+            maskedParameters = ((MaskedParameterizedStateMapping)this.mapper).getMaskedParameters();
+        }else {
+            maskedParameters = null;
+        }
     }
 
     public Task() {
@@ -104,6 +113,12 @@ public abstract class Task {
     public String getName(){
         return actionType.typeName();
     }
+
+    /**
+     *
+     * @return boolean indicating whether the state mapping masks parameters
+     */
+    public boolean isMasked() {return this.masked;}
 
     /**
      * determines if the current task is terminated in state s which parameterization a

--- a/src/palm/rmax/agent/RmaxModel.java
+++ b/src/palm/rmax/agent/RmaxModel.java
@@ -318,6 +318,9 @@ public abstract class RmaxModel extends PALMModel {
 
     public double getRmax() { return rmax; }
 
+    public GroundedTask getTask(){
+        return task;
+    }
     public void printDebugInfo() {
         System.out.println("\n\n\n******************************************************************************************************\n\n\n");
         for(HashableStateActionPair pair : approximateTransitions.keySet()) {

--- a/src/taxi/functions/amdp/GetCompletedPF.java
+++ b/src/taxi/functions/amdp/GetCompletedPF.java
@@ -2,6 +2,7 @@ package taxi.functions.amdp;
 
 import burlap.mdp.core.oo.propositional.PropositionalFunction;
 import burlap.mdp.core.oo.state.OOState;
+import taxi.hierarchies.tasks.get.state.GetStateMapper;
 import taxi.hierarchies.tasks.get.state.TaxiGetState;
 import utilities.MutableObject;
 
@@ -17,8 +18,9 @@ public class GetCompletedPF extends PropositionalFunction{
     @Override
     public boolean isTrue(OOState s, String... params) {
         if (!(s instanceof TaxiGetState)) { return false; }
-        String passengerName = params[0];
-        MutableObject passenger = (MutableObject) s.object(passengerName);
+//      String passengerName = params[0];
+//      MutableObject passenger = (MutableObject) s.object(passengerName);
+        MutableObject passenger = (MutableObject) s.object(GetStateMapper.GET_PASSENGER_ALIAS);
         if (passenger == null) { return false; }
         String pass_loc = (String) passenger.get(ATT_LOCATION);
         return pass_loc.equals(ATT_VAL_IN_TAXI);

--- a/src/taxi/functions/amdp/PutCompletedPF.java
+++ b/src/taxi/functions/amdp/PutCompletedPF.java
@@ -2,6 +2,7 @@ package taxi.functions.amdp;
 
 import burlap.mdp.core.oo.propositional.PropositionalFunction;
 import burlap.mdp.core.oo.state.OOState;
+import taxi.hierarchies.tasks.put.state.PutStateMapper;
 import taxi.hierarchies.tasks.put.state.TaxiPutState;
 import utilities.MutableObject;
 
@@ -17,8 +18,10 @@ public class PutCompletedPF extends PropositionalFunction{
     @Override
     public boolean isTrue(OOState s, String... params) {
         if (!(s instanceof TaxiPutState)) { return false; }
-        String passengerName = params[0];
-        MutableObject passenger = (MutableObject) s.object(passengerName);
+
+//        String passengerName = params[0];
+//        MutableObject passenger = (MutableObject) s.object(passengerName);
+       MutableObject passenger = (MutableObject) s.object(PutStateMapper.PUT_PASSENGER_ALIAS);
         if (passenger == null) { return false; }
         String passengerGoal = (String) passenger.get(ATT_GOAL_LOCATION);
         String passengerLocation = (String) passenger.get(ATT_LOCATION);

--- a/src/taxi/functions/amdp/PutFailurePF.java
+++ b/src/taxi/functions/amdp/PutFailurePF.java
@@ -2,6 +2,7 @@ package taxi.functions.amdp;
 
 import burlap.mdp.core.oo.propositional.PropositionalFunction;
 import burlap.mdp.core.oo.state.OOState;
+import taxi.hierarchies.tasks.put.state.PutStateMapper;
 import taxi.hierarchies.tasks.put.state.TaxiPutState;
 import utilities.MutableObject;
 
@@ -16,8 +17,9 @@ public class PutFailurePF extends PropositionalFunction{
     @Override
     public boolean isTrue(OOState s, String... params) {
         if (!(s instanceof TaxiPutState)) { return false; }
-        String passengerName = params[0];
-        MutableObject passenger = (MutableObject) s.object(passengerName);
+//        String passengerName = params[0];
+//        MutableObject passenger = (MutableObject) s.object(passengerName);
+          MutableObject passenger = (MutableObject) s.object(PutStateMapper.PUT_PASSENGER_ALIAS);
         if (passenger == null) { return false; }
         String passengerLocation = (String) passenger.get(ATT_LOCATION);
         return !passengerLocation.equals(ATT_VAL_IN_TAXI);

--- a/src/taxi/hierarchies/interfaces/MaskedParameterizedStateMapping.java
+++ b/src/taxi/hierarchies/interfaces/MaskedParameterizedStateMapping.java
@@ -1,0 +1,5 @@
+package taxi.hierarchies.interfaces;
+
+public interface MaskedParameterizedStateMapping extends ParameterizedStateMapping {
+    String[] getMaskedParameters();
+}

--- a/src/taxi/hierarchies/tasks/get/state/GetStateMapper.java
+++ b/src/taxi/hierarchies/tasks/get/state/GetStateMapper.java
@@ -2,7 +2,7 @@ package taxi.hierarchies.tasks.get.state;
 
 import burlap.mdp.core.oo.state.ObjectInstance;
 import burlap.mdp.core.state.State;
-import taxi.hierarchies.interfaces.ParameterizedStateMapping;
+import taxi.hierarchies.interfaces.MaskedParameterizedStateMapping;
 import taxi.state.TaxiPassenger;
 import taxi.state.TaxiState;
 
@@ -11,21 +11,25 @@ import java.util.List;
 
 import static taxi.TaxiConstants.*;
 
-public class GetStateMapper implements ParameterizedStateMapping {
+public class GetStateMapper implements MaskedParameterizedStateMapping {
 
-//    public static final String GET_PASSENGER_ALIAS = "**GET_PASSENGER_ALIAS**";
+    public static final String GET_PASSENGER_ALIAS = "**GET_PASSENGER_ALIAS**";
 
+    @Override
+    public String[] getMaskedParameters() {
+        return new String[]{CLASS_PASSENGER};
+    }
     //maps a base taxi state to L2
     @Override
-    public State mapState(State s, String...params) {
+    public State mapState(State s, String... params) {
         List<TaxiGetPassenger> passengers = new ArrayList<TaxiGetPassenger>();
         List<TaxiGetLocation> locations = new ArrayList<TaxiGetLocation>();
         TaxiState st = (TaxiState) s;
 
         // Get Taxi
         String taxiLocation = ATT_VAL_ON_ROAD;
-        int tx = (int)st.getTaxi().get(ATT_X);
-        int ty = (int)st.getTaxi().get(ATT_Y);
+        int tx = (int) st.getTaxi().get(ATT_X);
+        int ty = (int) st.getTaxi().get(ATT_Y);
         for (ObjectInstance location : st.objectsOfClass(CLASS_LOCATION)) {
             int lx = (int) location.get(ATT_X);
             int ly = (int) location.get(ATT_Y);
@@ -39,14 +43,14 @@ public class GetStateMapper implements ParameterizedStateMapping {
         TaxiGetAgent taxi = new TaxiGetAgent(CLASS_TAXI, taxiLocation);
 
         // Get Passengers
-        for(String passengerName : params){
+        for (String passengerName : params) {
             TaxiPassenger passenger = (TaxiPassenger) st.object(passengerName);
-            int px = (int)passenger.get(ATT_X);
-            int py = (int)passenger.get(ATT_Y);
+            int px = (int) passenger.get(ATT_X);
+            int py = (int) passenger.get(ATT_Y);
             boolean inTaxi = (boolean) passenger.get(ATT_IN_TAXI);
             String passengerLocation = ATT_VAL_IN_TAXI;
 
-            if(!inTaxi) {
+            if (!inTaxi) {
                 for (ObjectInstance location : st.objectsOfClass(CLASS_LOCATION)) {
                     int lx = (int) location.get(ATT_X);
                     int ly = (int) location.get(ATT_Y);
@@ -57,11 +61,10 @@ public class GetStateMapper implements ParameterizedStateMapping {
                     }
                 }
             }
-            passengers.add(new TaxiGetPassenger(passengerName, passengerLocation));
-//            passengers.add(new TaxiGetPassenger(GET_PASSENGER_ALIAS, passengerLocation));
+//            passengers.add(new TaxiGetPassenger(passengerName, passengerLocation));
+            passengers.add(new TaxiGetPassenger(GET_PASSENGER_ALIAS, passengerLocation));
         }
 
         return new TaxiGetState(taxi, passengers, locations);
     }
-
 }

--- a/src/taxi/hierarchies/tasks/put/state/PutStateMapper.java
+++ b/src/taxi/hierarchies/tasks/put/state/PutStateMapper.java
@@ -2,7 +2,7 @@ package taxi.hierarchies.tasks.put.state;
 
 import burlap.mdp.core.oo.state.ObjectInstance;
 import burlap.mdp.core.state.State;
-import taxi.hierarchies.interfaces.ParameterizedStateMapping;
+import taxi.hierarchies.interfaces.MaskedParameterizedStateMapping;
 import taxi.state.TaxiPassenger;
 import taxi.state.TaxiState;
 
@@ -11,10 +11,14 @@ import java.util.List;
 
 import static taxi.TaxiConstants.*;
 
-public class PutStateMapper implements ParameterizedStateMapping {
+public class PutStateMapper implements MaskedParameterizedStateMapping {
 
-//    public static final String PUT_PASSENGER_ALIAS = "**PUT_PASSENGER_ALIAS**";
+    public static final String PUT_PASSENGER_ALIAS = "**PUT_PASSENGER_ALIAS**";
 
+    @Override
+    public String[] getMaskedParameters() {
+        return new String[]{CLASS_PASSENGER};
+    }
     //maps a base taxi state to L2
     @Override
     public State mapState(State s, String... params) {
@@ -25,8 +29,8 @@ public class PutStateMapper implements ParameterizedStateMapping {
 
         // Get Taxi
         String taxiLocation = ATT_VAL_ON_ROAD;
-        int tx = (int)st.getTaxi().get(ATT_X);
-        int ty = (int)st.getTaxi().get(ATT_Y);
+        int tx = (int) st.getTaxi().get(ATT_X);
+        int ty = (int) st.getTaxi().get(ATT_Y);
         for (ObjectInstance location : st.objectsOfClass(CLASS_LOCATION)) {
             int lx = (int) location.get(ATT_X);
             int ly = (int) location.get(ATT_Y);
@@ -39,7 +43,7 @@ public class PutStateMapper implements ParameterizedStateMapping {
         }
         TaxiPutAgent taxi = new TaxiPutAgent(CLASS_TAXI, taxiLocation);
 
-        for(String passengerName : params){
+        for (String passengerName : params) {
             TaxiPassenger passenger = (TaxiPassenger) st.object(passengerName);
             String goal = (String) passenger.get(ATT_GOAL_LOCATION);
             boolean inTaxi = (boolean) passenger.get(ATT_IN_TAXI);
@@ -47,8 +51,8 @@ public class PutStateMapper implements ParameterizedStateMapping {
             if (inTaxi) {
                 location = ATT_VAL_IN_TAXI;
             } else {
-                int px = (int)passenger.get(ATT_X);
-                int py = (int)passenger.get(ATT_Y);
+                int px = (int) passenger.get(ATT_X);
+                int py = (int) passenger.get(ATT_Y);
                 for (ObjectInstance otherLocation : st.objectsOfClass(CLASS_LOCATION)) {
                     int lx = (int) otherLocation.get(ATT_X);
                     int ly = (int) otherLocation.get(ATT_Y);
@@ -57,12 +61,13 @@ public class PutStateMapper implements ParameterizedStateMapping {
                     }
                 }
             }
-            if (location.equals(ERROR)) { throw new RuntimeException("Error: passenger at invalid location in mapper"); }
-//            passengers.add(new TaxiPutPassenger(PUT_PASSENGER_ALIAS, goal, location));
-            passengers.add(new TaxiPutPassenger(passengerName, goal, location));
+            if (location.equals(ERROR)) {
+                throw new RuntimeException("Error: passenger at invalid location in mapper");
+            }
+            passengers.add(new TaxiPutPassenger(PUT_PASSENGER_ALIAS, goal, location));
+//            passengers.add(new TaxiPutPassenger(passengerName, goal, location));
         }
 
         return new TaxiPutState(taxi, passengers, locations);
     }
-
 }

--- a/src/testing/HierarchicalCharts.java
+++ b/src/testing/HierarchicalCharts.java
@@ -145,7 +145,7 @@ public class HierarchicalCharts {
 
     public static void main(String[] args) {
 
-        String configFile = "config/taxi/classic.yaml";
+        String configFile = "config/taxi/classic-2-fickle.yaml";
         if(args.length > 0) {
             configFile = args[0];
         }


### PR DESCRIPTION
Changes the taxi Expert hierarchy to share models for get and put. Updates PALM and RMAXQ to unmask primitive actions over masked objects, so our algorithms will solve truly abstract tasks that aren't object specific.